### PR TITLE
Add ... menu, add rated icon, fix duration formatting

### DIFF
--- a/SongDownloader/DownloadSource.cs
+++ b/SongDownloader/DownloadSource.cs
@@ -1,0 +1,8 @@
+namespace TootTallySongDownloader.SongDownloader;
+
+public enum DownloadSource
+{
+    TootTallyMirror,
+    Alternate,
+    Auto,
+}

--- a/SongDownloader/DownloadState.cs
+++ b/SongDownloader/DownloadState.cs
@@ -2,27 +2,27 @@ using TootTallyCore.Graphics.ProgressCounters;
 
 namespace TootTallySongDownloader;
 
-internal record DownloadState
+internal abstract record DownloadState
 {
     /// <summary>
     /// Waiting for a response from the TootTally API to see if this chart has a download/some metadata
     /// </summary>
-    internal record Waiting : DownloadState;
+    internal sealed record Waiting : DownloadState;
 
     /// <summary>
     /// User does not have the chart but a download is available
     /// </summary>
-    internal record DownloadAvailable : DownloadState;
+    internal sealed record DownloadAvailable : DownloadState;
 
     /// <summary>
     /// User does not have the chart and no download could be found
     /// </summary>
-    internal record DownloadUnavailable : DownloadState;
+    internal sealed record DownloadUnavailable : DownloadState;
 
     /// <summary>
     /// The chart is currently downloading
     /// </summary>
-    internal record Downloading : DownloadState
+    internal sealed record Downloading : DownloadState
     {
         internal ProgressCounter Progress;
     }
@@ -30,5 +30,5 @@ internal record DownloadState
     /// <summary>
     /// The user has the chart
     /// </summary>
-    internal record Owned : DownloadState;
+    internal sealed record Owned : DownloadState;
 }

--- a/SongDownloader/SongDownloadObject.cs
+++ b/SongDownloader/SongDownloadObject.cs
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 
+using System;
 using BaboonAPI.Hooks.Tracks;
 using BepInEx;
 using Microsoft.FSharp.Core;
@@ -9,7 +10,9 @@ using TootTallyCore.Graphics.ProgressCounters;
 using TootTallyCore.Utils.Helpers;
 using TootTallyCore.Utils.TootTallyNotifs;
 using TootTallySettings;
+using TootTallySongDownloader.SongDownloader;
 using TootTallySongDownloader.Ui;
+using TrombLoader.CustomTracks;
 using UnityEngine;
 using static TootTallyCore.APIServices.SerializableClass;
 
@@ -17,10 +20,60 @@ namespace TootTallySongDownloader
 {
     internal class SongDownloadObject : BaseTootTallySettingObject
     {
+        // Wow, sum types are verbose as heck in C#
+        /// <summary>
+        /// Info about the song download (filesize, extension)
+        /// </summary>
+        private abstract record FileDataState
+        {
+            /// <summary>
+            /// File info has not been requested yet (likely because the user had it downloaded already, so there was no
+            /// need to request anything)
+            /// </summary>
+            internal sealed record Unknown : FileDataState;
+
+            /// <summary>
+            /// File info request is in-flight
+            /// </summary>
+            internal sealed record WaitingOnRequest : FileDataState
+            {
+                internal readonly Coroutine Coroutine;
+
+                public WaitingOnRequest(Coroutine coroutine)
+                {
+                    Coroutine = coroutine;
+                }
+            }
+
+            /// <summary>
+            /// File info request succeeded
+            /// </summary>
+            internal sealed record HasData : FileDataState
+            {
+                internal readonly FileHelper.FileData FileData;
+
+                public HasData(FileHelper.FileData fileData)
+                {
+                    FileData = fileData;
+                }
+            }
+
+            /// <summary>
+            /// Failed to fetch file info (web request failed)
+            /// </summary>
+            internal sealed record ErrorFetchingData : FileDataState;
+        }
+
         private readonly SongRow _songRow;
         private readonly SongDataFromDB _song;
-        public bool isDownloadAvailable, isOwned;
-        private Coroutine? _fileSizeCoroutine;
+        public bool IsOwned;
+
+        public bool IsDownloadAvailable => !IsOwned && _fileData is FileDataState.HasData;
+
+        /// <summary>
+        /// Don't set this directly, use <c>SetFileData</c> which updates the UI as well
+        /// </summary>
+        private FileDataState _fileData = new FileDataState.Unknown();
 
         public SongDownloadObject(Transform canvasTransform, SongDataFromDB song, TootTallySettingPage page) : base($"Song{song.track_ref}", page)
         {
@@ -28,69 +81,28 @@ namespace TootTallySongDownloader
 
             _songRow = SongRow.Create()
                 .WithParent(canvasTransform)
+                .WithSongId(song.id)
                 .WithSongName(song.name)
                 .WithArtist(song.author)
                 .WithDurationSeconds(song.song_length)
                 .WithDifficulty(song.difficulty)
                 .WithCharter(song.charter)
-                .OnDownload(DownloadChart);
+                .WithIsDeletable(IsTrackDeletable(song.track_ref))
+                .OnDownload(() => DownloadChart(DownloadSource.Auto))
+                .OnDownloadFromTootTally(() => DownloadChart(DownloadSource.TootTallyMirror))
+                .OnDownloadFromAlternative(() => DownloadChart(DownloadSource.Alternate))
+                .OnDelete(DeleteChart);
 
-            //lol
-            if (FSharpOption<TromboneTrack>.get_IsNone(TrackLookup.tryLookup(song.track_ref)) && !((SongDownloadPage)_page).IsAlreadyDownloaded(song.track_ref))
+            if (!HasTrackDownloaded(song.track_ref))
             {
                 // User does not have the chart downloaded, query some info from the TootTally API
-                var link = FileHelper.GetDownloadLinkFromSongData(song);
-                if (link != null)
-                {
-                    _songRow.WithDownloadState(new DownloadState.Waiting());
-                    _fileSizeCoroutine = Plugin.Instance.StartCoroutine(TootTallyAPIService.GetFileSize(link, fileData =>
-                    {
-                        if (fileData != null)
-                        {
-                            if (!fileData.extension.Contains("zip"))
-                            {
-                                DisplaySongNotAvailable($"File is not zip: {fileData.extension}.");
-                            }
-                            else
-                            {
-                                _fileSizeCoroutine = null;
-                                // TODO
-                                // isDownloadAvailable = true;
-                                // _downloadButton = GameObjectFactory.CreateCustomButton(downloadBodyTf, Vector2.zero, new Vector2(64, 64), AssetManager.GetSprite("Download64.png"), "DownloadButton", DownloadChart).gameObject;
-                                // _downloadButton.transform.SetSiblingIndex(4);
-                                // _progressBar = GameObjectFactory.CreateProgressBar(_songRow.transform.Find("LatencyFG"), Vector2.zero, new Vector2(900, 20), false, "ProgressBar");
-                                // ((SongDownloadPage)_page).UpdateDownloadAllButton();
-
-                                _songRow
-                                    .WithFileSize(fileData.size)
-                                    .WithDownloadState(new DownloadState.DownloadAvailable());
-                            }
-                        }
-                        else
-                        {
-                            DisplaySongNotAvailable($"Couldn't access file at {link}");
-                        }
-                    }));
-                }
-                else
-                {
-                    // TODO
-                    DisplaySongNotAvailable("No download link found.");
-                }
+                TryRequestFileData();
             }
             else
             {
                 // User already has the song
                 _songRow.WithDownloadState(new DownloadState.Owned());
             }
-
-            //GameObjectFactory.CreateCustomButton(_songRow.transform, Vector2.zero, new Vector2(64, 64), AssetManager.GetSprite("global64.png"), "OpenWebButton", () => Application.OpenURL($"https://toottally.com/song/{song.id}/"));
-        }
-
-        public void DisplaySongNotAvailable(string error)
-        {
-            Plugin.LogWarning($"{_song.track_ref} cannot be downloaded: {error}");
-            _songRow.WithDownloadState(new DownloadState.DownloadUnavailable());
         }
 
         public void SetActive(bool active) => _songRow.GameObject.SetActive(active);
@@ -98,18 +110,32 @@ namespace TootTallySongDownloader
         public override void Dispose()
         {
             _songRow.Dispose();
-            if (_fileSizeCoroutine != null)
-                Plugin.Instance.StopCoroutine(_fileSizeCoroutine);
+
+            if (_fileData is FileDataState.WaitingOnRequest waitingOnRequest)
+            {
+                Plugin.Instance.StopCoroutine(waitingOnRequest.Coroutine);
+            }
         }
 
-        public void DownloadChart()
+        public void DownloadChart(DownloadSource dlSource)
         {
-            // isDownloadAvailable = false;
-
             var progress = new ProgressCounter();
             _songRow.WithDownloadState(new DownloadState.Downloading { Progress = progress });
 
-            var link = _song.mirror ?? _song.download;
+            var link = dlSource switch
+            {
+                DownloadSource.TootTallyMirror => _song.mirror,
+                DownloadSource.Alternate => _song.download,
+                DownloadSource.Auto => _song.mirror ?? _song.download,
+                _ => throw new ArgumentOutOfRangeException(nameof(dlSource), dlSource, null)
+            };
+            if (string.IsNullOrEmpty(link))
+            {
+                // Wuh oh
+                TootTallyNotifManager.DisplayError("Missing download link");
+                return;
+            }
+
             Plugin.Instance.StartCoroutine(TootTallyAPIService.DownloadZipFromServer(
                 link,
                 progress,
@@ -119,17 +145,121 @@ namespace TootTallySongDownloader
                     {
                         var downloadDir = Path.Combine(Path.GetDirectoryName(Plugin.Instance.Info.Location)!, "Downloads/");
                         var fileName = $"{_song.id}.zip";
-                        if (!Directory.Exists(downloadDir))
-                            Directory.CreateDirectory(downloadDir);
-                        FileHelper.WriteBytesToFile(downloadDir, fileName, data);
+
+                        try
+                        {
+                            if (!Directory.Exists(downloadDir))
+                                Directory.CreateDirectory(downloadDir);
+                        }
+                        catch (IOException e)
+                        {
+                            Plugin.LogError(e.ToString());
+
+                            TootTallyNotifManager.DisplayNotif("IO error creating download directory");
+                            _songRow.WithDownloadState(new DownloadState.DownloadAvailable());
+
+                            return;
+                        }
+                        catch (UnauthorizedAccessException e)
+                        {
+                            Plugin.LogError(e.ToString());
+
+                            TootTallyNotifManager.DisplayNotif("Insufficient permissions while creating download directory");
+                            _songRow.WithDownloadState(new DownloadState.DownloadAvailable());
+
+                            return;
+                        }
+                        catch (Exception e)
+                        {
+                            Plugin.LogError(e.ToString());
+
+                            TootTallyNotifManager.DisplayNotif("Unknown error creating download directory (check logs!)");
+                            _songRow.WithDownloadState(new DownloadState.DownloadAvailable());
+
+                            return;
+                        }
+
+                        try
+                        {
+                            FileHelper.WriteBytesToFile(downloadDir, fileName, data);
+                        }
+                        catch (IOException e)
+                        {
+                            Plugin.LogError(e.ToString());
+
+                            TootTallyNotifManager.DisplayNotif("IO error writing ZIP archive");
+                            _songRow.WithDownloadState(new DownloadState.DownloadAvailable());
+
+                            return;
+                        }
+                        catch (UnauthorizedAccessException e)
+                        {
+                            Plugin.LogError(e.ToString());
+
+                            TootTallyNotifManager.DisplayNotif("Insufficient permissions while writing ZIP archive");
+                            _songRow.WithDownloadState(new DownloadState.DownloadAvailable());
+
+                            return;
+                        }
+                        catch (Exception e)
+                        {
+                            Plugin.LogError(e.ToString());
+
+                            TootTallyNotifManager.DisplayNotif("Unknown error writing ZIP archive (check logs!)");
+                            _songRow.WithDownloadState(new DownloadState.DownloadAvailable());
+
+                            return;
+                        }
 
                         var source = Path.Combine(downloadDir, fileName);
                         var destination = Path.Combine(Paths.BepInExRootPath, "CustomSongs/");
-                        FileHelper.ExtractZipToDirectory(source, destination);
 
-                        FileHelper.DeleteFile(downloadDir, fileName);
+                        try
+                        {
+                            FileHelper.ExtractZipToDirectory(source, destination);
+                        }
+                        catch (InvalidDataException e)
+                        {
+                            Plugin.LogError(e.ToString());
 
-                        isOwned = true;
+                            TootTallyNotifManager.DisplayNotif("Downloaded file was not a ZIP archive");
+                            _songRow.WithDownloadState(new DownloadState.DownloadAvailable());
+
+                            return;
+                        }
+                        catch (IOException e)
+                        {
+                            Plugin.LogError(e.ToString());
+
+                            TootTallyNotifManager.DisplayNotif("IO error extracting ZIP archive");
+                            _songRow.WithDownloadState(new DownloadState.DownloadAvailable());
+
+                            return;
+                        }
+                        catch (UnauthorizedAccessException e)
+                        {
+                            Plugin.LogError(e.ToString());
+
+                            TootTallyNotifManager.DisplayNotif("Insufficient permissions while extracting ZIP archive");
+                            _songRow.WithDownloadState(new DownloadState.DownloadAvailable());
+
+                            return;
+                        }
+                        catch (Exception e)
+                        {
+                            Plugin.LogError(e.ToString());
+
+                            TootTallyNotifManager.DisplayNotif("Unknown error extracting ZIP archive (check logs!)");
+                            _songRow.WithDownloadState(new DownloadState.DownloadAvailable());
+
+                            return;
+                        }
+                        finally
+                        {
+                            FileHelper.DeleteFile(downloadDir, fileName);
+                        }
+
+                        IsOwned = true;
 
                         _songRow.WithDownloadState(new DownloadState.Owned());
 
@@ -144,6 +274,223 @@ namespace TootTallySongDownloader
                     }
                 }
             ));
+        }
+
+        /// <summary>
+        /// Get the directory a chart resides in, for downloaded TrombLoader tracks
+        /// </summary>
+        /// <returns>The directory, or <c>null</c> if the track is not loaded by TrombLoader</returns>
+        private string? GetLocalChartDirectory()
+        {
+            var trackOpt = TrackLookup.tryLookup(_song.track_ref);
+            if (FSharpOption<TromboneTrack>.get_IsNone(trackOpt))
+            {
+                return null;
+            }
+
+            return (trackOpt.Value as CustomTrack)?.folderPath;
+        }
+
+        /// <summary>
+        /// Is <c>candidate</c> contained within <c>other</c>?
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Yoinked from https://stackoverflow.com/a/23354773
+        /// </para>
+        /// <para>
+        /// May raise DirectoryInfo construction exceptions - see
+        /// https://learn.microsoft.com/en-us/dotnet/api/system.io.directoryinfo.-ctor?view=net-9.0 and
+        /// https://learn.microsoft.com/en-us/dotnet/api/system.io.directoryinfo.parent?view=net-9.0
+        /// </para>
+        /// </remarks>
+        private static bool IsSubDirectoryOf(string candidate, string other)
+        {
+            var candidateInfo = new DirectoryInfo(candidate);
+            var otherInfo = new DirectoryInfo(other);
+
+            while (candidateInfo.Parent != null)
+            {
+                if (candidateInfo.Parent.FullName == otherInfo.FullName)
+                {
+                    return true;
+                }
+                else
+                {
+                    candidateInfo = candidateInfo.Parent;
+                }
+            }
+
+            return false;
+        }
+
+        private void DeleteChart()
+        {
+            var dir = GetLocalChartDirectory();
+            if (dir == null)
+            {
+                TootTallyNotifManager.DisplayNotif("Can only delete charts loaded by TrombLoader");
+                return;
+            }
+
+            try
+            {
+                // Sanity check, we *do not* want to delete anything outside the CustomSongs dir
+                var customSongsDir = Path.Combine(Paths.BepInExRootPath, "CustomSongs");
+                if (!IsSubDirectoryOf(dir, customSongsDir))
+                {
+                    TootTallyNotifManager.DisplayNotif("Refusing to delete chart outside of the CustomSongs folder");
+                    return;
+                }
+
+                try
+                {
+                    Directory.Delete(dir, recursive: true);
+                }
+                catch (IOException e)
+                {
+                    Plugin.LogError(e.ToString());
+                    TootTallyNotifManager.DisplayNotif("IO error deleting chart");
+                    return;
+                }
+                catch (UnauthorizedAccessException e)
+                {
+                    Plugin.LogError(e.ToString());
+                    TootTallyNotifManager.DisplayNotif("Insufficient permissions while deleting chart");
+                    return;
+                }
+
+                IsOwned = false;
+                _songRow.WithIsDeletable(false);
+
+                // Reload tracks when exiting this page
+                ((SongDownloadPage)_page).MarkTrackDeleted(_song.track_ref);
+
+                UpdateUiDownloadState();
+                TryRequestFileData(); // If we don't know the file info (eg: filesize), request it now
+
+                TootTallyNotifManager.DisplayNotif("Chart deleted");
+            }
+            catch (Exception e)
+            {
+                Plugin.LogError(e.ToString());
+                TootTallyNotifManager.DisplayNotif("Failed to delete chart (check logs!)");
+            }
+        }
+
+        private bool IsTrackDeletable(string trackRef)
+        {
+            var page = (SongDownloadPage)_page;
+            return FSharpOption<TromboneTrack>.get_IsSome(TrackLookup.tryLookup(trackRef)) && !page.WasTrackDeleted(trackRef);
+        }
+
+        private bool HasTrackDownloaded(string trackRef)
+        {
+            var page = (SongDownloadPage)_page;
+            return (FSharpOption<TromboneTrack>.get_IsSome(TrackLookup.tryLookup(trackRef)) && !page.WasTrackDeleted(trackRef))
+                   || page.IsAlreadyDownloaded(trackRef);
+        }
+
+        /// <summary>
+        /// Set <c>_fileData</c>, updating the UI along the way
+        /// </summary>
+        private void SetFileData(FileDataState newState)
+        {
+            _fileData = newState;
+            UpdateUiDownloadState();
+        }
+
+        private void UpdateUiDownloadState()
+        {
+            if (HasTrackDownloaded(_song.track_ref))
+            {
+                _songRow.WithDownloadState(new DownloadState.Owned());
+            }
+            else
+            {
+                switch (_fileData)
+                {
+                    case FileDataState.ErrorFetchingData:
+                        Debug.LogError($"NAH DATA");
+                        _songRow.WithDownloadState(new DownloadState.DownloadUnavailable());
+                        break;
+
+                    case FileDataState.HasData hasData:
+                        // "extension" isn't actually the extension here, it's the last part of the mime type >.<
+                        switch (hasData.FileData.extension)
+                        {
+                            case "zip":
+                            case "x-zip":
+                            case "zip-compressed":
+                            case "x-zip-compressed":
+                                _songRow
+                                    .WithFileSize(hasData.FileData.size)
+                                    .WithDownloadState(new DownloadState.DownloadAvailable());
+                                break;
+
+                            default:
+                                _songRow.WithDownloadState(new DownloadState.DownloadUnavailable());
+                                break;
+                        }
+                        break;
+
+                    case FileDataState.Unknown:
+                    case FileDataState.WaitingOnRequest:
+                        _songRow.WithDownloadState(new DownloadState.Waiting());
+                        break;
+
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(_fileData));
+                }
+            }
+
+            var page = (SongDownloadPage)_page;
+            page.UpdateDownloadAllButton();
+        }
+
+        private void TryRequestFileData()
+        {
+            if (_fileData is not FileDataState.Unknown)
+            {
+                // Already requested file data, don't try again
+                return;
+            }
+
+            var link = FileHelper.GetDownloadLinkFromSongData(_song);
+            if (link != null)
+            {
+                _songRow.WithDownloadState(new DownloadState.Waiting());
+                SetFileData(
+                    new FileDataState.WaitingOnRequest(
+                        Plugin.Instance.StartCoroutine(TootTallyAPIService.GetFileSize(link, OnFileDataFetched))
+                    )
+                );
+            }
+            else
+            {
+                Plugin.LogWarning($"{_song.track_ref} cannot be downloaded: no download link found");
+                SetFileData(new FileDataState.ErrorFetchingData());
+            }
+        }
+
+        private void OnFileDataFetched(FileHelper.FileData? fileData)
+        {
+            if (fileData != null)
+            {
+                if (!fileData.extension.Contains("zip"))
+                {
+                    Plugin.LogWarning($"{_song.track_ref} cannot be downloaded: File is not zip: {fileData.extension}");
+                    SetFileData(new FileDataState.ErrorFetchingData());
+                }
+                else
+                {
+                    SetFileData(new FileDataState.HasData(fileData));
+                }
+            }
+            else
+            {
+                Plugin.LogWarning($"{_song.track_ref} cannot be downloaded: got null FileData");
+            }
         }
     }
 }

--- a/SongDownloader/SongDownloadObject.cs
+++ b/SongDownloader/SongDownloadObject.cs
@@ -87,6 +87,7 @@ namespace TootTallySongDownloader
                 .WithDurationSeconds(song.song_length)
                 .WithDifficulty(song.difficulty)
                 .WithCharter(song.charter)
+                .WithIsRated(song.is_rated)
                 .WithIsDeletable(IsTrackDeletable(song.track_ref))
                 .OnDownload(() => DownloadChart(DownloadSource.Auto))
                 .OnDownloadFromTootTally(() => DownloadChart(DownloadSource.TootTallyMirror))

--- a/SongDownloader/SongDownloadObject.cs
+++ b/SongDownloader/SongDownloadObject.cs
@@ -382,7 +382,10 @@ namespace TootTallySongDownloader
         private bool IsTrackDeletable(string trackRef)
         {
             var page = (SongDownloadPage)_page;
-            return FSharpOption<TromboneTrack>.get_IsSome(TrackLookup.tryLookup(trackRef)) && !page.WasTrackDeleted(trackRef);
+            var trackOpt = TrackLookup.tryLookup(trackRef);
+            return FSharpOption<TromboneTrack>.get_IsSome(trackOpt)
+                   && trackOpt.Value is CustomTrack
+                   && !page.WasTrackDeleted(trackRef);
         }
 
         private bool HasTrackDownloaded(string trackRef)
@@ -412,7 +415,6 @@ namespace TootTallySongDownloader
                 switch (_fileData)
                 {
                     case FileDataState.ErrorFetchingData:
-                        Debug.LogError($"NAH DATA");
                         _songRow.WithDownloadState(new DownloadState.DownloadUnavailable());
                         break;
 

--- a/SongDownloader/SongDownloadPage.cs
+++ b/SongDownloader/SongDownloadPage.cs
@@ -7,6 +7,7 @@ using TootTallyCore.Graphics;
 using TootTallyCore.Utils.Assets;
 using TootTallyCore.Utils.TootTallyNotifs;
 using TootTallySettings;
+using TootTallySongDownloader.SongDownloader;
 using UnityEngine;
 using UnityEngine.UI;
 using static TootTallyCore.APIServices.SerializableClass;
@@ -22,9 +23,10 @@ namespace TootTallySongDownloader
         private GameObject _downloadAllButton;
         private Toggle _toggleRated, _toggleUnrated, _toggleNotOwned;
         private LoadingIcon _loadingIcon;
-        private List<string> _trackRefList;
-        private List<string> _newDownloadedTrackRefs;
-        private List<SongDownloadObject> _downloadObjectList;
+        private readonly List<string> _trackRefList = [];
+        private readonly List<string> _newDownloadedTrackRefs = [];
+        private readonly List<string> _deletedTrackRefs = [];
+        private readonly List<SongDownloadObject> _downloadObjectList = [];
         public bool ShowNotOwnedOnly => _toggleNotOwned.isOn;
 
 
@@ -45,10 +47,6 @@ namespace TootTallySongDownloader
         public override void Initialize()
         {
             base.Initialize();
-            _trackRefList = new List<string>();
-            _newDownloadedTrackRefs = new List<string>();
-            _downloadObjectList = new List<SongDownloadObject>();
-
             _inputField = TootTallySettingObjectFactory.CreateInputField(_fullPanel.transform, $"{name}InputField", DEFAULT_OBJECT_SIZE, DEFAULT_FONTSIZE, DEFAULT_INPUT_TEXT, false);
             _inputField.onSubmit.AddListener(value => Search(_inputField.text));
             _inputField.GetComponent<RectTransform>().anchorMin = _inputField.GetComponent<RectTransform>().anchorMax = new Vector2(.72f, .7f);
@@ -72,13 +70,13 @@ namespace TootTallySongDownloader
             _downloadAllButton = GameObjectFactory.CreateCustomButton(_fullPanel.transform, new Vector2(-1330, -87), new Vector2(200, 60), "Download All", "DownloadAllButton", DownloadAll).gameObject;
             _downloadAllButton.SetActive(false);
 
-            // SetSongRowPrefab();
             _backButton.button.onClick.AddListener(() =>
             {
-                if (_newDownloadedTrackRefs.Count > 0)
+                if (_newDownloadedTrackRefs.Count > 0 || _deletedTrackRefs.Count > 0)
                 {
-                    TootTallyNotifManager.DisplayNotif("New tracks detected, Reloading songs...\nLagging is normal.");
+                    TootTallyNotifManager.DisplayNotif("Reloading songs...");
                     _newDownloadedTrackRefs.Clear();
+                    _deletedTrackRefs.Clear();
                     TootTallyCore.Plugin.Instance.Invoke("ReloadTracks", 0.35f);
                 }
             });
@@ -151,18 +149,16 @@ namespace TootTallySongDownloader
                 _prevButton = GameObjectFactory.CreateCustomButton(_fullPanel.transform, new Vector2(-700, -175), new Vector2(50, 50), "<<", $"{name}PrevButton", () => Search(searchInfo.previous, false)).gameObject;
         }
 
-#nullable disable
-
         public void UpdateDownloadAllButton()
         {
             if (!_downloadAllButton.activeSelf)
-                _downloadAllButton.SetActive(_downloadObjectList.Any(o => o.isDownloadAvailable));
+                _downloadAllButton.SetActive(_downloadObjectList.Any(o => o.IsDownloadAvailable));
         }
 
         private void DownloadAll()
         {
             _downloadAllButton.SetActive(false);
-            _downloadObjectList.Where(o => o.isDownloadAvailable).Do(o => o.DownloadChart());
+            _downloadObjectList.Where(o => o.IsDownloadAvailable).Do(o => o.DownloadChart(DownloadSource.Auto));
         }
 
         private void AddSongToPage(SongDataFromDB song)
@@ -170,17 +166,31 @@ namespace TootTallySongDownloader
             if (_trackRefList.Contains(song.track_ref)) return;
             _trackRefList.Add(song.track_ref);
             var songDownloadObj = new SongDownloadObject(gridPanel.transform, song, this);
-            songDownloadObj.SetActive(!(_toggleNotOwned.isOn && songDownloadObj.isOwned));
+            songDownloadObj.SetActive(!(_toggleNotOwned.isOn && songDownloadObj.IsOwned));
             _downloadObjectList.Add(songDownloadObj);
             AddSettingObjectToList(songDownloadObj);
         }
 
         private void OnNotOwnedToggle(bool value)
         {
-            _downloadObjectList.ForEach(x => x.SetActive(!(value && x.isOwned)));
+            _downloadObjectList.ForEach(x => x.SetActive(!(value && x.IsOwned)));
         }
 
-        public void AddTrackRefToDownloadedSong(string trackref) => _newDownloadedTrackRefs.Add(trackref);
+        internal void AddTrackRefToDownloadedSong(string trackref)
+        {
+            _newDownloadedTrackRefs.Add(trackref);
+            _deletedTrackRefs.Remove(trackref);
+        }
+
+        internal void MarkTrackDeleted(string trackref)
+        {
+            _deletedTrackRefs.Add(trackref);
+            _newDownloadedTrackRefs.Remove(trackref);
+        }
+
         public bool IsAlreadyDownloaded(string trackref) => _newDownloadedTrackRefs.Contains(trackref);
+        public bool WasTrackDeleted(string trackref) => _deletedTrackRefs.Contains(trackref);
+
+#nullable disable
     }
 }

--- a/SongDownloader/Ui/DownloadButton.cs
+++ b/SongDownloader/Ui/DownloadButton.cs
@@ -78,10 +78,6 @@ public class DownloadButton
         bodyLayoutElem.preferredWidth = 64f;
 
         var button = bodyGo.GetComponent<Button>();
-        button.onClick.AddListener(() =>
-        {
-            Debug.Log("OHAI!");
-        });
 
         // Create panel fill ///////////////////////////////////////////////////////////////////////////////////////////
         var fillGo = new GameObject(

--- a/SongDownloader/Ui/MainBody.cs
+++ b/SongDownloader/Ui/MainBody.cs
@@ -19,6 +19,7 @@ public class MainBody
     private readonly StatDisplay _durationStatDisplay;
     private readonly StatDisplay _difficultyStatDisplay;
     private readonly StatDisplay _charterStatDisplay;
+    private readonly GameObject _ratedIconGo;
 
     /// <summary>
     /// Private ctor, use <c>Create</c> instead
@@ -29,7 +30,8 @@ public class MainBody
         TMP_Text artistText,
         StatDisplay durationStatDisplay,
         StatDisplay difficultyStatDisplay,
-        StatDisplay charterStatDisplay
+        StatDisplay charterStatDisplay,
+        GameObject ratedIconGo
     )
     {
         _gameObject = gameObject;
@@ -38,6 +40,7 @@ public class MainBody
         _durationStatDisplay = durationStatDisplay;
         _difficultyStatDisplay = difficultyStatDisplay;
         _charterStatDisplay = charterStatDisplay;
+        _ratedIconGo = ratedIconGo;
     }
 
     internal static MainBody Create()
@@ -163,6 +166,17 @@ public class MainBody
         rightTopBoxLayout.childAlignment = TextAnchor.UpperRight;
         rightTopBoxLayout.spacing = 8f;
 
+        var ratedIcon = new GameObject(
+            "RatedIcon",
+            typeof(RectTransform),
+            typeof(Image)
+        );
+        var ratedIconTf = (RectTransform)ratedIcon.transform;
+        ratedIconTf.SetParent(rightTopBoxTf, false);
+        var ratedIconImage = ratedIcon.GetComponent<Image>();
+        ratedIconImage.sprite = AssetManager.GetSprite("rated64.png");
+        ((RectTransform)ratedIconImage.transform).sizeDelta = Vector2.one * 20f;
+
         var durationStatDisplay = StatDisplay.Create().WithParent(rightTopBoxTf).WithIcon("time64.png");
         var difficultyStatDisplay = StatDisplay.Create().WithParent(rightTopBoxTf).WithIcon("stardiff64.png");
 
@@ -190,15 +204,14 @@ public class MainBody
 
         var charterStatDisplay = StatDisplay.Create().WithParent(rightBottomBoxTf).WithIcon("Pencil64.png");
 
-        // TODO: Add ranked icon somewhere
-
         return new MainBody(
             gameObject: bodyGo,
             songNameText: songNameText,
             artistText: artistText,
             durationStatDisplay: durationStatDisplay,
             difficultyStatDisplay: difficultyStatDisplay,
-            charterStatDisplay: charterStatDisplay
+            charterStatDisplay: charterStatDisplay,
+            ratedIconGo: ratedIcon
         );
     }
 
@@ -253,6 +266,12 @@ public class MainBody
     internal MainBody WithCharter(string charterDisplayName)
     {
         _charterStatDisplay.WithText(charterDisplayName);
+        return this;
+    }
+
+    internal MainBody WithIsRated(bool rated)
+    {
+        _ratedIconGo.SetActive(rated);
         return this;
     }
 }

--- a/SongDownloader/Ui/MainBody.cs
+++ b/SongDownloader/Ui/MainBody.cs
@@ -222,8 +222,24 @@ public class MainBody
 
     internal MainBody WithDurationSeconds(float seconds)
     {
-        var time = TimeSpan.FromSeconds(seconds);
-        var stringTime = $"{(time.Hours != 0 ? (time.Hours + ":") : "")}{(time.Minutes != 0 ? time.Minutes : "0")}:{(time.Seconds != 0 ? time.Seconds : "00"):00}";
+        var totalSeconds = (uint)seconds;
+        var dispSeconds = totalSeconds % 60;
+
+        var totalMinutes = totalSeconds / 60;
+        var dispMinutes = totalMinutes % 60;
+
+        var totalHours = totalMinutes / 60;
+
+        string stringTime;
+        if (totalHours > 0)
+        {
+            stringTime = $"{totalHours}:{dispMinutes:D2}:{dispSeconds:D2}";
+        }
+        else
+        {
+            stringTime = $"{dispMinutes}:{dispSeconds:D2}";
+        }
+
         _durationStatDisplay.WithText(stringTime);
         return this;
     }

--- a/SongDownloader/Ui/MenuOverlay.cs
+++ b/SongDownloader/Ui/MenuOverlay.cs
@@ -1,0 +1,275 @@
+using TMPro;
+using TootTallyCore.Graphics;
+using TootTallyCore.Graphics.Animations;
+using TootTallyCore.Utils.Assets;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.UI;
+
+namespace TootTallySongDownloader.Ui;
+
+internal class MenuOverlay
+{
+    private readonly GameObject _canvasGameObject;
+    private readonly GameObject _bodyGameObject;
+
+    private bool _isHiding = false;
+
+    /// <summary>
+    /// Private ctor, use <c>Create</c> instead
+    /// </summary>
+    private MenuOverlay(
+        GameObject canvasGameObject,
+        GameObject bodyGameObject
+    )
+    {
+        _canvasGameObject = canvasGameObject;
+        _bodyGameObject = bodyGameObject;
+    }
+
+    internal static MenuOverlay Create()
+    {
+        // Create a new canvas in the scene
+        var canvasGo = new GameObject(
+            "MenuOverlayCanvas",
+            typeof(RectTransform),
+            typeof(Canvas),
+            typeof(CanvasScaler),
+            typeof(GraphicRaycaster),
+            typeof(CanvasGroup)
+        );
+        var canvasTf = canvasGo.transform;
+
+        var canvas = canvasGo.GetComponent<Canvas>();
+        canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+        canvas.overrideSorting = true;
+        canvas.sortingOrder = 2;
+        var canvasScaler = canvasGo.GetComponent<CanvasScaler>();
+        canvasScaler.referenceResolution = new Vector2(1920, 1080);
+        canvasScaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+
+        // Fullscreen invisible button to close the menu ///////////////////////////////////////////////////////////////
+        var closeButtonGo = new GameObject(
+            "CloseButton",
+            typeof(RectTransform),
+            typeof(GraphicRaycaster),
+            typeof(Button),
+            typeof(Image)
+        );
+
+        var closeButtonTf = (RectTransform)closeButtonGo.transform;
+        closeButtonTf.SetParent(canvasTf, false);
+        closeButtonTf.anchorMin = new Vector2(0f, 0f);
+        closeButtonTf.anchorMax = new Vector2(1f, 1f);
+        closeButtonTf.offsetMin = new Vector2(0f, 0f);
+        closeButtonTf.offsetMax = new Vector2(0f, 0f);
+
+        var closeButton = closeButtonGo.GetComponent<Button>();
+
+        // Need an image, even if it is invisible, as a hit target
+        var closeButtonImage = closeButtonGo.GetComponent<Image>();
+        closeButtonImage.color = new Color(0f, 0f, 0f, 0f);
+
+        // Menu body ///////////////////////////////////////////////////////////////////////////////////////////////////
+        var mainBodyGo = new GameObject(
+            "MenuBody",
+            typeof(RectTransform),
+            typeof(OverlayLayoutGroup),
+            typeof(ContentSizeFitter)
+        );
+
+        var mainBodyTf = (RectTransform)mainBodyGo.transform;
+        mainBodyTf.SetParent(canvasTf, false);
+
+        var mainBodyCsf = mainBodyGo.GetComponent<ContentSizeFitter>();
+        mainBodyCsf.horizontalFit = ContentSizeFitter.FitMode.PreferredSize;
+        mainBodyCsf.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+
+        // Add main panel fill /////////////////////////////////////////////////////////////////////////////////////////
+        var panelFill = new GameObject(
+            "PanelFill",
+            typeof(RectTransform),
+            typeof(CanvasRenderer),
+            typeof(Image)
+        );
+
+        var panelFillTf = (RectTransform)panelFill.transform;
+        panelFillTf.SetParent(mainBodyTf, false);
+        panelFillTf.anchorMin = Vector2.zero;
+        panelFillTf.anchorMax = Vector2.one;
+        panelFillTf.offsetMin = Vector2.zero;
+        panelFillTf.offsetMax = Vector2.zero;
+
+        var panelFillImage = panelFill.GetComponent<Image>();
+        var fillLeftTexture = AssetManager.GetTexture("RoundedBoxLeftFill.png");
+        panelFillImage.sprite = Sprite.Create(
+            fillLeftTexture,
+            new Rect(0f, 0f, fillLeftTexture.width, fillLeftTexture.height),
+            Vector2.one * .5f,
+            100f,
+            1,
+            SpriteMeshType.FullRect,
+            Vector4.one * 4f,
+            false
+        );
+        panelFillImage.type = Image.Type.Sliced;
+        panelFillImage.color = new Color(0.102f, 0.102f, 0.102f); // TODO: Use theme colors
+
+        // Add main panel border ///////////////////////////////////////////////////////////////////////////////////////
+        var panelBorderGo = new GameObject(
+            "PanelBorder",
+            typeof(RectTransform),
+            typeof(CanvasRenderer),
+            typeof(Image)
+        );
+
+        var panelBorderTf = (RectTransform)panelBorderGo.transform;
+        panelBorderTf.SetParent(mainBodyTf, false);
+        panelBorderTf.anchorMin = Vector2.zero;
+        panelBorderTf.anchorMax = Vector2.one;
+        panelBorderTf.offsetMin = Vector2.zero;
+        panelBorderTf.offsetMax = Vector2.zero;
+
+        var panelBorderImage = panelBorderGo.GetComponent<Image>();
+        var borderLeftTexture = AssetManager.GetTexture("RoundedBoxLeftBorder.png");
+        panelBorderImage.sprite = Sprite.Create(
+            borderLeftTexture,
+            new Rect(0f, 0f, borderLeftTexture.width, borderLeftTexture.height),
+            Vector2.one * .5f,
+            100f,
+            1,
+            SpriteMeshType.FullRect,
+            Vector4.one * 4f,
+            false
+        );
+        panelBorderImage.type = Image.Type.Sliced;
+        panelBorderImage.color = new Color(0.910f, 0.212f, 0.333f); // TODO: Use theme colors
+
+        // Add list-of-items ///////////////////////////////////////////////////////////////////////////////////////////
+        var itemListGo = new GameObject(
+            "ItemList",
+            typeof(RectTransform),
+            typeof(VerticalLayoutGroup)
+        );
+
+        var itemListTf = itemListGo.transform;
+        itemListTf.SetParent(mainBodyTf, false);
+
+        var itemListVlg = itemListGo.GetComponent<VerticalLayoutGroup>();
+        itemListVlg.padding = new RectOffset(1, 1, 1, 1);
+
+        var ret = new MenuOverlay(canvasGo, mainBodyGo);
+        closeButton.onClick.AddListener(() => ret.Hide());
+
+        return ret;
+    }
+
+    internal MenuOverlay WithItem(string text, UnityAction onClick)
+    {
+        var itemListTf = _bodyGameObject.transform.Find("ItemList");
+
+        var buttonGo = new GameObject(
+            "Item",
+            typeof(RectTransform),
+            typeof(CanvasRenderer),
+            typeof(Button),
+            typeof(Image),
+            typeof(OverlayLayoutGroup)
+        );
+
+        var buttonTf = buttonGo.transform;
+        buttonTf.SetParent(itemListTf, false);
+
+        var buttonImage = buttonGo.GetComponent<Image>();
+
+        var buttonButton = buttonGo.GetComponent<Button>();
+        buttonButton.transition = Selectable.Transition.ColorTint;
+        buttonButton.targetGraphic = buttonImage;
+        buttonButton.colors = new ColorBlock
+        {
+            normalColor = new Color(0f, 0f, 0f, 0f),
+            highlightedColor = new Color(0.910f, 0.212f, 0.333f), // TODO: Use theme colors
+            pressedColor = new Color(0.557f, 0.129f, 0.204f), // TODO: Use theme colors
+            colorMultiplier = 1f,
+        };
+        buttonButton.onClick.AddListener(() =>
+        {
+            onClick();
+            Hide();
+        });
+
+        var buttonOlg = buttonGo.GetComponent<OverlayLayoutGroup>();
+        buttonOlg.padding = new RectOffset(4, 4, 4, 4);
+
+        var textComponent = GameObjectFactory.CreateSingleText(buttonTf, "Text", text);
+        textComponent.enableWordWrapping = false;
+        textComponent.fontSize = 18f;
+        textComponent.horizontalAlignment = HorizontalAlignmentOptions.Left;
+
+        return this;
+    }
+
+    /// <summary>
+    /// Open the menu at the mouse cursor's location
+    /// </summary>
+    internal void ShowAtCursor()
+    {
+        // Get cursor position on the canvas
+        RectTransformUtility.ScreenPointToLocalPointInRectangle(
+            (RectTransform)_canvasGameObject.transform,
+            Input.mousePosition,
+            _canvasGameObject.GetComponent<Canvas>().worldCamera,
+            out var cursorCanvasPos
+        );
+
+        // Position at the cursor
+        var mainBodyTf = (RectTransform)_bodyGameObject.transform;
+        mainBodyTf.position = _canvasGameObject.transform.TransformPoint(cursorCanvasPos);
+
+        LayoutRebuilder.ForceRebuildLayoutImmediate(mainBodyTf);
+        var height = LayoutUtility.GetPreferredHeight(mainBodyTf);
+        if (mainBodyTf.position.y - height < 0f)
+        {
+            // Show menu going upwards
+            mainBodyTf.pivot = new Vector2(0f, 0f);
+        }
+        else
+        {
+            // Show menu going downwards
+            mainBodyTf.pivot = new Vector2(0f, 1f);
+        }
+
+        // Animate it in
+        mainBodyTf.localScale = new Vector3(0f, 0f, 1f);
+        TootTallyAnimationManager.AddNewScaleAnimation(
+            _bodyGameObject,
+            Vector2.one,
+            0.35f,
+            new SecondDegreeDynamicsAnimation(3.5f, 1f, 1.2f)
+        );
+    }
+
+    private void Hide()
+    {
+        if (_isHiding)
+        {
+            return;
+        }
+        _isHiding = true;
+
+        // Animate it out
+        TootTallyAnimationManager.AddNewScaleAnimation(
+            _bodyGameObject,
+            Vector2.zero,
+            0.35f,
+            new SecondDegreeDynamicsAnimation(3.5f, 1f, 1.2f)
+        );
+
+        // Prevent further interaction, so we can click on stuff underneath
+        _canvasGameObject.GetComponent<CanvasGroup>().interactable = false;
+        _canvasGameObject.GetComponent<CanvasGroup>().blocksRaycasts = false;
+
+        // Destroy once the animation is over
+        Object.Destroy(_canvasGameObject, 0.35f);
+    }
+}

--- a/SongDownloader/Ui/MoreInfoButton.cs
+++ b/SongDownloader/Ui/MoreInfoButton.cs
@@ -1,7 +1,8 @@
 #nullable enable
 
+using System;
+using System.Collections.Generic;
 using TootTallyCore.Utils.Assets;
-using TootTallyCore.Utils.TootTallyNotifs;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -14,6 +15,14 @@ public class MoreInfoButton
 {
     private readonly GameObject _gameObject;
     private RectTransform Transform => (RectTransform)_gameObject.transform;
+
+    private int _songId;
+    private bool _isDeletable = false;
+    private DownloadState _downloadState = new DownloadState.Waiting();
+
+    private readonly List<Action> _onDownloadFromTootTally = [];
+    private readonly List<Action> _onDownloadFromAlternative = [];
+    private readonly List<Action> _onDelete = [];
 
     /// <summary>
     /// Private ctor, use <c>Create</c> instead
@@ -48,11 +57,6 @@ public class MoreInfoButton
         bodyLayoutElem.preferredWidth = 24f;
 
         var button = bodyGo.GetComponent<Button>();
-        button.onClick.AddListener(() =>
-        {
-            TootTallyNotifManager.DisplayNotif("Coming soon... Sorry!");
-            Plugin.LogInfo("NOT IMPLEMENTED YET!! OHAI!");
-        });
 
         // Create panel fill ///////////////////////////////////////////////////////////////////////////////////////////
         var fillGo = new GameObject(
@@ -133,12 +137,111 @@ public class MoreInfoButton
 
         iconGo.GetComponent<Image>().sprite = AssetManager.GetSprite("MoreInfoIcon.png");
 
-        return new MoreInfoButton(bodyGo);
+        var ret = new MoreInfoButton(bodyGo);
+        button.onClick.AddListener(() => ret.OpenMenu());
+
+        return ret;
     }
 
     internal MoreInfoButton WithParent(Transform parent)
     {
         Transform.SetParent(parent, false);
         return this;
+    }
+
+    internal MoreInfoButton WithSongId(int songId)
+    {
+        _songId = songId;
+        return this;
+    }
+
+    internal MoreInfoButton WithDownloadState(DownloadState downloadState)
+    {
+        _downloadState = downloadState;
+        return this;
+    }
+
+    internal MoreInfoButton WithIsDeletable(bool isDeletable)
+    {
+        _isDeletable = isDeletable;
+        return this;
+    }
+
+    internal MoreInfoButton OnDownloadFromTootTally(Action callback)
+    {
+        _onDownloadFromTootTally.Add(callback);
+        return this;
+    }
+
+    internal MoreInfoButton OnDownloadFromAlternative(Action callback)
+    {
+        _onDownloadFromAlternative.Add(callback);
+        return this;
+    }
+
+    internal MoreInfoButton OnDelete(Action callback)
+    {
+        _onDelete.Add(callback);
+        return this;
+    }
+
+    private void OpenMenu()
+    {
+        var menu = MenuOverlay.Create()
+            .WithItem(
+                "View on TootTally.com",
+                () => Application.OpenURL($"https://toottally.com/song/{_songId}/")
+            );
+
+        switch (_downloadState)
+        {
+            case DownloadState.DownloadAvailable:
+                menu.WithItem(
+                    "Download from TootTally",
+                    () => _onDownloadFromTootTally.ForEach(action => action())
+                );
+                menu.WithItem(
+                    "Download from alternate source",
+                    () => _onDownloadFromAlternative.ForEach(action => action())
+                );
+                break;
+
+            case DownloadState.DownloadUnavailable:
+                menu.WithItem(
+                    "Try download anyway from TootTally",
+                    () => _onDownloadFromTootTally.ForEach(action => action())
+                );
+                menu.WithItem(
+                    "Try download anyway from alternate source",
+                    () => _onDownloadFromAlternative.ForEach(action => action())
+                );
+                break;
+
+            case DownloadState.Owned:
+                menu.WithItem(
+                    "Redownload from TootTally",
+                    () => _onDownloadFromTootTally.ForEach(action => action())
+                );
+                menu.WithItem(
+                    "Redownload from alternate source",
+                    () => _onDownloadFromAlternative.ForEach(action => action())
+                );
+                break;
+
+            case DownloadState.Waiting:
+            case DownloadState.Downloading:
+                // Don't show download options
+                break;
+        }
+
+        if (_isDeletable)
+        {
+            menu.WithItem(
+                "Delete",
+                () => _onDelete.ForEach(action => action())
+            );
+        }
+
+        menu.ShowAtCursor();
     }
 }

--- a/SongDownloader/Ui/OverlayLayoutGroup.cs
+++ b/SongDownloader/Ui/OverlayLayoutGroup.cs
@@ -1,0 +1,99 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace TootTallySongDownloader.Ui;
+
+/// <summary>
+/// Overlay items on top of each other. This takes the size of the largest child item's sizes.
+/// </summary>
+public class OverlayLayoutGroup : UIBehaviour, ILayoutElement, ILayoutGroup
+{
+    public float minWidth { private set; get; }
+    public float preferredWidth { private set; get; }
+    public float flexibleWidth { private set; get; }
+    public float minHeight { private set; get; }
+    public float preferredHeight { private set; get; }
+    public float flexibleHeight { private set; get; }
+    public int layoutPriority => 0;
+
+    public RectOffset padding = new();
+
+    [System.NonSerialized] private RectTransform _rectTransform;
+    private RectTransform RectTransform
+    {
+        get
+        {
+            if (_rectTransform == null) _rectTransform = GetComponent<RectTransform>();
+            return _rectTransform;
+        }
+    }
+
+    public void CalculateLayoutInputHorizontal()
+    {
+        minWidth = 0f;
+        preferredWidth = 0f;
+        flexibleWidth = 0f;
+
+        for (var i = 0; i < RectTransform.childCount; i++)
+        {
+            var childTf = (RectTransform)RectTransform.GetChild(i).transform;
+
+            minWidth = Mathf.Max(minWidth, LayoutUtility.GetMinWidth(childTf));
+            preferredWidth = Mathf.Max(preferredWidth, LayoutUtility.GetPreferredWidth(childTf));
+            flexibleWidth = Mathf.Max(flexibleWidth, LayoutUtility.GetFlexibleWidth(childTf));
+        }
+
+        var horizPadding = padding.left + padding.right;
+        minWidth += horizPadding;
+        preferredWidth += horizPadding;
+        flexibleWidth += horizPadding;
+    }
+
+    public void CalculateLayoutInputVertical()
+    {
+        minHeight = 0f;
+        preferredHeight = 0f;
+        flexibleHeight = 0f;
+
+        for (var i = 0; i < RectTransform.childCount; i++)
+        {
+            var childTf = (RectTransform)RectTransform.GetChild(i).transform;
+
+            minHeight = Mathf.Max(minHeight, LayoutUtility.GetMinHeight(childTf));
+            preferredHeight = Mathf.Max(preferredHeight, LayoutUtility.GetPreferredHeight(childTf));
+            flexibleHeight = Mathf.Max(flexibleHeight, LayoutUtility.GetFlexibleHeight(childTf));
+        }
+
+        var vertPadding = padding.bottom + padding.top;
+        minHeight += vertPadding;
+        preferredHeight += vertPadding;
+        flexibleHeight += vertPadding;
+    }
+
+    public void SetLayoutHorizontal()
+    {
+        for (var i = 0; i < RectTransform.childCount; i++)
+        {
+            var childTf = (RectTransform)RectTransform.GetChild(i).transform;
+
+            childTf.anchorMin = new Vector2(0f, childTf.anchorMin.y);
+            childTf.anchorMax = new Vector2(1f, childTf.anchorMax.y);
+            childTf.offsetMin = new Vector2(padding.left, childTf.offsetMin.y);
+            childTf.offsetMax = new Vector2(-padding.right, childTf.offsetMax.y);
+        }
+    }
+
+    public void SetLayoutVertical()
+    {
+        for (var i = 0; i < RectTransform.childCount; i++)
+        {
+            var childTf = (RectTransform)RectTransform.GetChild(i).transform;
+
+            childTf.anchorMin = new Vector2(childTf.anchorMin.x, 0f);
+            childTf.anchorMax = new Vector2(childTf.anchorMax.x, 1f);
+            childTf.offsetMin = new Vector2(childTf.offsetMin.x, padding.bottom);
+            childTf.offsetMax = new Vector2(childTf.offsetMax.x, -padding.top);
+        }
+    }
+}

--- a/SongDownloader/Ui/SongRow.cs
+++ b/SongDownloader/Ui/SongRow.cs
@@ -2,7 +2,6 @@
 
 using System;
 using UnityEngine;
-using UnityEngine.Events;
 using UnityEngine.UI;
 
 namespace TootTallySongDownloader.Ui;
@@ -17,15 +16,22 @@ public class SongRow : IDisposable
     private RectTransform Transform => (RectTransform)GameObject.transform;
 
     private readonly MainBody _mainBody;
+    private readonly MoreInfoButton _moreInfoButton;
     private readonly DownloadButton _downloadButton;
 
     /// <summary>
     /// Private ctor, use <c>Create</c> instead
     /// </summary>
-    private SongRow(GameObject gameObject, MainBody mainBody, DownloadButton downloadButton)
+    private SongRow(
+        GameObject gameObject,
+        MainBody mainBody,
+        MoreInfoButton moreInfoButton,
+        DownloadButton downloadButton
+    )
     {
         GameObject = gameObject;
         _mainBody = mainBody;
+        _moreInfoButton = moreInfoButton;
         _downloadButton = downloadButton;
     }
 
@@ -49,10 +55,10 @@ public class SongRow : IDisposable
 
         // Create each part of the row /////////////////////////////////////////////////////////////////////////////////
         var mainBody = MainBody.Create().WithParent(songRowTf);
-        MoreInfoButton.Create().WithParent(songRowTf);
+        var moreInfoButton = MoreInfoButton.Create().WithParent(songRowTf);
         var downloadButton = DownloadButton.Create().WithParent(songRowTf);
 
-        return new SongRow(rowGo, mainBody, downloadButton);
+        return new SongRow(rowGo, mainBody, moreInfoButton, downloadButton);
     }
 
     internal SongRow WithParent(Transform parent)
@@ -94,6 +100,7 @@ public class SongRow : IDisposable
     internal SongRow WithDownloadState(DownloadState state)
     {
         _downloadButton.WithDownloadState(state);
+        _moreInfoButton.WithDownloadState(state);
         return this;
     }
 
@@ -103,9 +110,39 @@ public class SongRow : IDisposable
         return this;
     }
 
+    internal SongRow WithSongId(int songId)
+    {
+        _moreInfoButton.WithSongId(songId);
+        return this;
+    }
+
+    internal SongRow WithIsDeletable(bool isDeletable)
+    {
+        _moreInfoButton.WithIsDeletable(isDeletable);
+        return this;
+    }
+
     internal SongRow OnDownload(Action callback)
     {
         _downloadButton.OnDownload(callback);
+        return this;
+    }
+
+    internal SongRow OnDownloadFromTootTally(Action callback)
+    {
+        _moreInfoButton.OnDownloadFromTootTally(callback);
+        return this;
+    }
+
+    internal SongRow OnDownloadFromAlternative(Action callback)
+    {
+        _moreInfoButton.OnDownloadFromAlternative(callback);
+        return this;
+    }
+
+    internal SongRow OnDelete(Action callback)
+    {
+        _moreInfoButton.OnDelete(callback);
         return this;
     }
 

--- a/SongDownloader/Ui/SongRow.cs
+++ b/SongDownloader/Ui/SongRow.cs
@@ -97,6 +97,12 @@ public class SongRow : IDisposable
         return this;
     }
 
+    internal SongRow WithIsRated(bool rated)
+    {
+        _mainBody.WithIsRated(rated);
+        return this;
+    }
+
     internal SongRow WithDownloadState(DownloadState state)
     {
         _downloadButton.WithDownloadState(state);


### PR DESCRIPTION
- Makes the `...` menu work
    - Can view chart on TootTally (someone maybe test this for me since it doesn't work in proton)
    - Can (re)download from toottally or an alternate source (..though alt links tend to fail almost all of the time...)
    - Can delete charts too
- Also fixes duration formatting for long charts
- Adds rated icon for rated charts
    - Might want to duplicate the rated64.png asset here, or move it into TootTallyCore - so we're not dependent on TootTallyLeaderboard being installed for this icon to show up
- Also more graceful (read: verbose af) error handling for download/extract errors